### PR TITLE
Add Issue Approvals

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,3 +36,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+
+### Issue Approval:
+- [ ]  Issue approved by:

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -19,3 +19,7 @@ Who would benefit from the documentation?
 
 **Ideas for the documentation**
 Add ideas about the documentation here.
+
+
+### Issue Approval:
+- [ ]  Issue approved by:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+
+### Feature Approval:
+- [ ]  Feature approved by:

--- a/.github/ISSUE_TEMPLATE/new-frontend-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-frontend-feature.md
@@ -13,3 +13,7 @@ assignees: ''
 ### In-Depth Feature Description
 
 ### Images for Reference:
+
+
+### Feature Approval:
+- [ ]  Feature approved by:


### PR DESCRIPTION
Modify Issue Templates to add an approval checkbox at the bottom of each created issue.

Newly created issues will need to be approved by one other developer before it can be assigned and work on it can begin.